### PR TITLE
Added flag to enable forced update of existing apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ _[optional]_  user-friendly title for the application
 
 _[optional]_  level of verbosity of rsconnect::deployApp(). Defaults to `normal`, other options are `quiet` or `verbose`.
 
+#### forceUpdate
+
+_[optional]_  If set to 'true', update any previously-deployed app without asking.
+
 ## Packages
 
 This action uses the rocker/shiny-verse:latest docker image as a base. This image includes recent versions of most package commonly used in shiny apps and the tidyverse.

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   accountSecret:
     description: secret, see https://www.shinyapps.io/admin/#/tokens. Generating a new token/secret pair for this action is recommended, so that you can revoke it without affecting other deployments.
     required: true
+  forceUpdate:
+    description: If set, update any previously-deployed app without asking. If FALSE, ask to update
+    required: false
 runs:
   using: docker
   image: Dockerfile

--- a/deploy.R
+++ b/deploy.R
@@ -46,10 +46,18 @@ appFiles <- optional("INPUT_APPFILES")
 appFileManifest <- optional("INPUT_APPFILEMANIFEST")
 appTitle <- optional("INPUT_APPTITLE")
 logLevel <- optional("INPUT_LOGLEVEL")
+forceUpdate <- optional("INPUT_FORCEUPDATE")
 
 # process appFiles
 if (!is.null(appFiles)) {
   appFiles <- unlist(strsplit(appFiles, ",", TRUE))
+}
+
+# check if this is a forced update
+if (forceUpdate == 'true') {
+    forceUpdate = TRUE
+} else {
+    forceUpdate = FALSE
 }
 
 # set up account
@@ -64,5 +72,6 @@ rsconnect::deployApp(
   appFileManifest = appFileManifest,
   appName = appName,
   appTitle = appTitle,
-  account = accountName
+  account = accountName,
+  forceUpdate = forceUpdate
 )


### PR DESCRIPTION
Added a flag that enables forced update for already installed apps. Without this flag, the deployment fails if an app with the same name already exists.